### PR TITLE
fixing public setter

### DIFF
--- a/pylibshout.pyx
+++ b/pylibshout.pyx
@@ -385,8 +385,7 @@ cdef class Shout:
             return shout_get_public(self.shout_t)
 
         def __set__(self, public):
-            public = bool(public)
-            i = shout_set_dumpfile(self.shout_t, public)
+            i = shout_set_public(self.shout_t, int(bool(public)))
             if i != 0:
                 raise Exception(i, 'Public is not correct')
 


### PR DESCRIPTION
The _public_ property setter was calling the _shout_set_dumpfile_ instead of _shout_set_public_.
Just fixed it.
